### PR TITLE
added distinction between php entities and  storage

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -92,7 +92,7 @@
     "editorOverviewRuler.commonContentForeground": "#ffc60055",
     "editorOverviewRuler.currentContentForeground": "#ee3a4355",
     "editorOverviewRuler.incomingContentForeground": "#3ad90055",
-    "editorRuler.foreground": "#ffc600",
+    "editorRuler.foreground": "#ffc60033",
     // editorSuggestWidget
     "editorSuggestWidget.background": "#15232d",
     "editorSuggestWidget.border": "#15232d",
@@ -102,7 +102,7 @@
     // editorWarning
     "editorWarning.border": "#ffffff00",
     "editorWarning.foreground": "#ffc600",
-    "editorWhitespace.foreground": "#ffffff00",
+    "editorWhitespace.foreground": "#ffc60033",
     "editorWidget.background": "#15232d",
     "editorWidget.border": "#0d3a58",
     "errorForeground": "#f00",
@@ -666,6 +666,13 @@
       "name": "[TYPESCRIPT] - Storage",
       "scope": "source.ts storage",
       "settings": {
+        "foreground": "#9effff"
+      }
+    },
+    {
+      "name": "[PHP] - Entity",
+      "scope": "source.php entity",
+      "settings":{
         "foreground": "#9effff"
       }
     }


### PR DESCRIPTION
made the ruler much less intrusive
made whitespace visible if requested (https://github.com/wesbos/cobalt2-vscode/issues/6)

before:
<img width="833" alt="screen shot 2017-09-13 at 11 36 41" src="https://user-images.githubusercontent.com/251322/30370424-d77031a6-9877-11e7-9a93-1c360ec3b6ee.png">

after:
![screen shot 2017-09-13 at 11 36 12](https://user-images.githubusercontent.com/251322/30370435-e05f0f62-9877-11e7-9a66-f6f01da034e7.png)

