### PR TITLE
Terminal parameter/flag colours

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -240,7 +240,7 @@
     "terminal.ansiBrightBlue": "#0088ff",
     "terminal.ansiBrightMagenta": "#fb94ff",
     "terminal.ansiBrightCyan": "#80fcff",
-    "terminal.ansiBrightWhite": "#ffffff",
+    "terminal.ansiBrightWhite": "#193549",
     "terminal.background": "#122738",
     "terminal.foreground": "#ffffff",
     "terminalCursor.background": "#ffc600",

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -233,7 +233,7 @@
     "terminal.ansiMagenta": "#fb94ff",
     "terminal.ansiCyan": "#80fcff",
     "terminal.ansiWhite": "#ffffff",
-    "terminal.ansiBrightBlack": "#000000",
+    "terminal.ansiBrightBlack": "#0050A4",
     "terminal.ansiBrightRed": "#ff628c",
     "terminal.ansiBrightGreen": "#3ad900",
     "terminal.ansiBrightYellow": "#ffc600",


### PR DESCRIPTION
Hi Wes,

I have fixed an issue highlighted in issue #44 where command line parameters/flags where appearing in black and therefore not readable against the darker terminal background.

My fix addresses this and uses the blue #0050A4 used elsewhere as a selection colour. The fix addresses the visibility issue of parameters/flags when typed and also whenever the user makes a selection.

Thanks,
Alisdair
