### PR TITLE
Closes #63 - Reduce Install Size

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,6 @@
+.vscode/**
+demo/**
+images/logo.sketch
+.gitignore
+.gitattributes
+.editorconfig

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       }
     ]
   },
-  "dependencies": {
+  "devDependencies": {
     "nodemon": "^1.12.0",
     "vsce": "^1.30.0"
   }


### PR DESCRIPTION
Hi @wesbos ,

This PR refers to Issue #63, to reduce the install size. It now uses `devDependencies` instead of `dependencies`, and also _ignores_ some other files while publishing the extension.

It reduced from 3.4Mb to 500Kb.
