### PR TITLE
Add support for git status colors in file explorer

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -245,6 +245,12 @@
     "terminal.foreground": "#ffffff",
     "terminalCursor.background": "#ffc600",
     "terminalCursor.foreground": "#ffc600",
+    // Git status colors in File Explorer
+    "gitDecoration.modifiedResourceForeground": "#ffc600",
+    "gitDecoration.deletedResourceForeground": "#ff628c",
+    "gitDecoration.untrackedResourceForeground": "#3ad900",
+    "gitDecoration.ignoredResourceForeground": "#ff628c",
+    "gitDecoration.conflictingResourceForeground": "#FF7200",
     // textBlockQuote
     "textBlockQuote.background": "#193549",
     "textBlockQuote.border": "#0088ff",


### PR DESCRIPTION
Applying Cobalt2 colors to Git file decorations in File Explorer.

`theme/cobalt2.json` Modified.
`newfile.js` Untracked.
`node_modules` Ignored.
`css.css` Conflicting.

![cobalt2-vscode-git-status-colors](https://user-images.githubusercontent.com/4334778/33020765-1edf1ea6-ce08-11e7-92c0-70affab9c729.png)
