### PR TITLE
Added a border to the peek section and removed the black background in the peek match.

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -171,9 +171,9 @@
     "panelTitle.activeForeground": "#ffc600",
     "panelTitle.inactiveForeground": "#aaa",
     // "peekView
-    "peekView.border": "#0d3a58",
+    "peekView.border": "#ffc600",
     "peekViewEditor.background": "#193549",
-    "peekViewEditor.matchHighlightBackground": "#15232d",
+    "peekViewEditor.matchHighlightBackground": "#19354900",
     "peekViewEditorGutter.background": "#122738",
     "peekViewResult.background": "#15232d",
     "peekViewResult.fileForeground": "#aaa",


### PR DESCRIPTION
Before:
<img width="413" alt="web_themes_custom_nsf_theme_css_custom_css_ _nsf_ _visual_studio_code__unsupported_" src="https://user-images.githubusercontent.com/203078/34535795-afc75a80-f088-11e7-8d73-994adc8869c0.png">


After:
<img width="348" alt="_extension_development_host__-_web_themes_custom_nsf_theme_css_custom_css_ _nsf_ _visual_studio_code__unsupported_" src="https://user-images.githubusercontent.com/203078/34535752-8ab59be4-f088-11e7-9f33-7cb61de990dd.png">
