### PR TITLE
Fix Fat Cursor VS Code V1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@
   "files.trimTrailingWhitespace": true,
   "editor.fontWeight": "400",
   "prettier.eslintIntegration": true,
-  // this isn't really underline-thin but we hack it to be a thicker cursor
-  "editor.cursorStyle": "underline-thin",
+  "editor.cursorStyle": "line",
+  "editor.cursorWidth": 3,
   "editor.cursorBlinking": "solid",
   // Very important: Install this plugin: https://github.com/be5invis/vscode-custom-css
   // you'll need to change this to an absolute path on your computer

--- a/cobalt2-custom-hacks.css
+++ b/cobalt2-custom-hacks.css
@@ -2,20 +2,6 @@
   font-family: "Operator Mono", "Inconsolata", monospace;
 }
 
-/*
-  Fat Cursor.
-  This overwrites the "underline thin" style since that is one that can be styled with CSS
-  So set your settings to:
-  "editor.cursorStyle": "underline-thin",
-*/
-.monaco-editor .cursors-layer.cursor-underline-thin-style > .cursor {
-  border-bottom-width: 0;
-  border-left-width: 3px;
-  border-left-style: solid;
-  background: transparent !important;
-  box-sizing: border-box;
-}
-
 /* This makes the dirty tab circle yellow */
 .vs-dark
   .monaco-workbench


### PR DESCRIPTION
The CSS hack for making the fat cursor is no longer working after updating to v1.20, plus in the same release we can control cursor width natively via using `editor.cursorWidth` settings.

Everyone can enjoy the fat cursor now without using the `.vscodestyles.css` file anymore! 🙌