### PR TITLE
Darker colors for inserted/removed text background

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -27,9 +27,9 @@
     // description
     "descriptionForeground": "#aaa",
     // diff
-    "diffEditor.insertedTextBackground": "#3ad90011",
+    "diffEditor.insertedTextBackground": "#3ad90033",
     "diffEditor.insertedTextBorder": "#3ad90055",
-    "diffEditor.removedTextBackground": "#ee3a4311",
+    "diffEditor.removedTextBackground": "#ee3a4333",
     "diffEditor.removedTextBorder": "#ee3a4355",
     // dropdown
     "dropdown.background": "#193549",


### PR DESCRIPTION
Before:
<img width="666" alt="screen shot 2018-02-08 at 11 35 32 am" src="https://user-images.githubusercontent.com/10458061/36039703-e17bedfe-0df5-11e8-87d5-7324f1802a9b.png">

After:
<img width="316" alt="screen shot 2018-02-09 at 11 52 47 pm" src="https://user-images.githubusercontent.com/10458061/36039679-ced169ae-0df5-11e8-840d-7193c77c7c4a.png">
<img width="578" alt="screen shot 2018-02-09 at 11 49 36 pm" src="https://user-images.githubusercontent.com/10458061/36039681-cf107612-0df5-11e8-9f17-d2635c9ab2a7.png">
