### PR TITLE
FIX: HTML closing tag selected color should be more deep. #68

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "theme-cobalt2",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -64,9 +64,9 @@
     // "editor.inactiveSelectionBackground": "",
     // Word Highlights! This happens when you move your cursor inside a variable
     // Strong is the one where your cursor currently is
-    "editor.wordHighlightStrongBackground": "#FFFFFF0D",
+    "editor.wordHighlightStrongBackground": "#ffffff21",
     // and this one is the rest of them
-    "editor.wordHighlightBackground": "#FFFFFF0D",
+    "editor.wordHighlightBackground": "#ffffff21",
     "editorBracketMatch.background": "#0d3a58",
     "editorBracketMatch.border": "#ffc60080",
     "editorCodeLens.foreground": "#aaa",


### PR DESCRIPTION
@wesbos Suggestion from issue was to change the color of the closing tag to make it more deeper and visible and then take a look at making the editor text highlight color more vibrant. 

Couldn't change the color of the closing tag to be deeper without changing the color of the opening tag. So to make it more visible editor text highlight color changed so it wouldn't be as faint as it was and allow the closing tag to be visible when the matching opening tag is selected. 

Before: 
![before](https://user-images.githubusercontent.com/14850570/36044879-b3dd3a9c-0ddc-11e8-8ba9-37405b01847a.png)

After:
![after](https://user-images.githubusercontent.com/14850570/36044904-c25d517e-0ddc-11e8-8966-6e151edd09d5.png)

Closes #68

