### PR TITLE
Added color to C# attributes (annotations) and italics to HTML attributes

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -772,13 +772,21 @@
       }
     },
     {
+      "name": "[C#] - Annotations",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#fb94ff"
+      }
+    },
+    {
       "name": "Italicsify for Operator Mono",
       "scope": [
         "modifier",
         "this",
         "comment",
         "storage.modifier.js",
-        "entity.other.attribute-name.js"
+        "entity.other.attribute-name.js",
+        "entity.other.attribute-name.html"
       ],
       "settings": {
         "fontStyle": "italic"

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -775,7 +775,21 @@
       "name": "[C#] - Annotations",
       "scope": "storage.type.cs",
       "settings": {
-        "foreground": "#fb94ff"
+        "foreground": "#9effff"
+      }
+    },
+    {
+      "name": "[C#] - Properties",
+      "scope": "entity.name.variable.property.cs",
+      "settings": {
+        "foreground": "#9effff"
+      }
+    },
+    {
+      "name": "[C#] - Storage modifiers",
+      "scope": "storage.modifier.cs",
+      "settings": {
+        "foreground": "#80ffbb"
       }
     },
     {


### PR DESCRIPTION
The italics in HTML tag attributes were showing only in .jsx and .html files, but not in in Razor and Twig (and possibly other html dialects).