### PR TITLE
Add new Notification Center Styles for VSCode 1.21+

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -152,7 +152,16 @@
     "merge.currentHeaderBackground": "#ffffff00",
     "merge.incomingContentBackground": "#ffffff00",
     "merge.incomingHeaderBackground": "#ffffff00",
-    // notification
+    // notification colors - The colors below only apply for VS Code versions 1.21 and higher.
+    "notificationCenter.border": "#ffc600",
+    "notificationCenterHeader.foreground": "#aaa",
+    "notificationCenterHeader.background": "#122738",
+    "notificationToast.border": "#ffc600",
+    "notifications.foreground": "#aaa",
+    "notifications.background": "#122738",
+    "notifications.border": "#ffc600",
+    "notificationLink.foreground": "#ffc600",
+    // notification - If you target VS Code versions before the 1.21 (February 2018) release, these are the old (no longer supported) colors:
     "notification.background": "#ffc600",
     "notification.buttonBackground": "#0088ff",
     "notification.buttonForeground": "#fff",
@@ -271,10 +280,7 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "#0088ff"
@@ -359,20 +365,14 @@
     },
     {
       "name": "String",
-      "scope": [
-        "string",
-        "punctuation.definition.string"
-      ],
+      "scope": ["string", "punctuation.definition.string"],
       "settings": {
         "foreground": "#a5ff90"
       }
     },
     {
       "name": "String Template",
-      "scope": [
-        "string.template",
-        "punctuation.definition.string.template"
-      ],
+      "scope": ["string.template", "punctuation.definition.string.template"],
       "settings": {
         "foreground": "#3ad900"
       }
@@ -407,10 +407,7 @@
     },
     {
       "name": "[CSS] - Entity",
-      "scope": [
-        "source.css entity",
-        "source.stylus entity"
-      ],
+      "scope": ["source.css entity", "source.stylus entity"],
       "settings": {
         "foreground": "#3ad900"
       }
@@ -431,10 +428,7 @@
     },
     {
       "name": "[CSS] - Support",
-      "scope": [
-        "source.css support",
-        "source.stylus support"
-      ],
+      "scope": ["source.css support", "source.stylus support"],
       "settings": {
         "foreground": "#a5ff90"
       }
@@ -465,10 +459,7 @@
     },
     {
       "name": "[CSS] - Variable",
-      "scope": [
-        "source.css variable",
-        "source.stylus variable"
-      ],
+      "scope": ["source.css variable", "source.stylus variable"],
       "settings": {
         "foreground": "#9effff"
       }
@@ -503,8 +494,10 @@
       }
     },
     {
-      "name": "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
-      "scope": "punctuation.definition.string.begin, punctuation.definition.string.end",
+      "name":
+        "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
+      "scope":
+        "punctuation.definition.string.begin, punctuation.definition.string.end",
       "settings": {
         "foreground": "#92fc79"
       }
@@ -683,20 +676,14 @@
     },
     {
       "name": "[MARKDOWN] - Inline Code",
-      "scope": [
-        "fenced_code.block.language",
-        "markup.inline.raw.markdown"
-      ],
+      "scope": ["fenced_code.block.language", "markup.inline.raw.markdown"],
       "settings": {
         "foreground": "#9effff"
       }
     },
     {
       "name": "[MARKDOWN] - Code Block",
-      "scope": [
-        "fenced_code.block.language",
-        "markup.inline.raw.markdown"
-      ],
+      "scope": ["fenced_code.block.language", "markup.inline.raw.markdown"],
       "settings": {
         "foreground": "#9effff"
       }


### PR DESCRIPTION
A: Added new Notification Center styling for VSCode 1.21 (February 2018) with commenting. Additional commenting added to deprecated styles left in place for theme compatibility with VSCode 1.20 and prior.

B: Values that are arrays are formatted to one line. See Token Colors section.