### PR TITLE
Fixes Issue 96 - Status Bar Styling for Active Debug

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -152,7 +152,16 @@
     "merge.currentHeaderBackground": "#ffffff00",
     "merge.incomingContentBackground": "#ffffff00",
     "merge.incomingHeaderBackground": "#ffffff00",
-    // notification
+    // notification colors - The colors below only apply for VS Code versions 1.21 and higher.
+    "notificationCenter.border": "#ffc600",
+    "notificationCenterHeader.foreground": "#aaa",
+    "notificationCenterHeader.background": "#122738",
+    "notificationToast.border": "#ffc600",
+    "notifications.foreground": "#aaa",
+    "notifications.background": "#122738",
+    "notifications.border": "#ffc600",
+    "notificationLink.foreground": "#ffc600",
+    // notification - If you target VS Code versions before the 1.21 (February 2018) release, these are the old (no longer supported) colors:
     "notification.background": "#ffc600",
     "notification.buttonBackground": "#0088ff",
     "notification.buttonForeground": "#fff",
@@ -271,10 +280,7 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "#0088ff"
@@ -359,20 +365,14 @@
     },
     {
       "name": "String",
-      "scope": [
-        "string",
-        "punctuation.definition.string"
-      ],
+      "scope": ["string", "punctuation.definition.string"],
       "settings": {
         "foreground": "#a5ff90"
       }
     },
     {
       "name": "String Template",
-      "scope": [
-        "string.template",
-        "punctuation.definition.string.template"
-      ],
+      "scope": ["string.template", "punctuation.definition.string.template"],
       "settings": {
         "foreground": "#3ad900"
       }
@@ -407,10 +407,7 @@
     },
     {
       "name": "[CSS] - Entity",
-      "scope": [
-        "source.css entity",
-        "source.stylus entity"
-      ],
+      "scope": ["source.css entity", "source.stylus entity"],
       "settings": {
         "foreground": "#3ad900"
       }
@@ -431,10 +428,7 @@
     },
     {
       "name": "[CSS] - Support",
-      "scope": [
-        "source.css support",
-        "source.stylus support"
-      ],
+      "scope": ["source.css support", "source.stylus support"],
       "settings": {
         "foreground": "#a5ff90"
       }
@@ -465,10 +459,7 @@
     },
     {
       "name": "[CSS] - Variable",
-      "scope": [
-        "source.css variable",
-        "source.stylus variable"
-      ],
+      "scope": ["source.css variable", "source.stylus variable"],
       "settings": {
         "foreground": "#9effff"
       }
@@ -503,8 +494,10 @@
       }
     },
     {
-      "name": "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
-      "scope": "punctuation.definition.string.begin, punctuation.definition.string.end",
+      "name":
+        "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
+      "scope":
+        "punctuation.definition.string.begin, punctuation.definition.string.end",
       "settings": {
         "foreground": "#92fc79"
       }
@@ -683,20 +676,14 @@
     },
     {
       "name": "[MARKDOWN] - Inline Code",
-      "scope": [
-        "fenced_code.block.language",
-        "markup.inline.raw.markdown"
-      ],
+      "scope": ["fenced_code.block.language", "markup.inline.raw.markdown"],
       "settings": {
         "foreground": "#9effff"
       }
     },
     {
       "name": "[MARKDOWN] - Code Block",
-      "scope": [
-        "fenced_code.block.language",
-        "markup.inline.raw.markdown"
-      ],
+      "scope": ["fenced_code.block.language", "markup.inline.raw.markdown"],
       "settings": {
         "foreground": "#9effff"
       }

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -215,13 +215,15 @@
     // statusBar
     "statusBar.background": "#15232d",
     "statusBar.border": "#0d3a58",
-    "statusBar.debuggingBackground": "#ffc600",
-    "statusBar.debuggingForeground": "#15232d",
+    "statusBar.debuggingBackground": "#15232d",
+    "statusBar.debuggingBorder": "#ffc600",
+    "statusBar.debuggingForeground": "#ffc600",
     "statusBar.foreground": "#aaa",
     "statusBar.noFolderBackground": "#15232d",
+    "statusBar.noFolderBorder": "#0d3a58",
     "statusBar.noFolderForeground": "#aaa",
     "statusBarItem.activeBackground": "#0088ff",
-    // "statusBarItem.hoverBackground": "#0d3a58",
+    "statusBarItem.hoverBackground": "#0d3a58",
     "statusBarItem.prominentBackground": "#15232d",
     "statusBarItem.prominentHoverBackground": "#0d3a58",
     // tab

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -216,9 +216,11 @@
     "statusBar.background": "#15232d",
     "statusBar.border": "#0d3a58",
     "statusBar.debuggingBackground": "#15232d",
-    "statusBar.debuggingForeground": "#0d3a58",
+    "statusBar.debuggingBorder": "#ffc600",
+    "statusBar.debuggingForeground": "#ffc600",
     "statusBar.foreground": "#aaa",
     "statusBar.noFolderBackground": "#15232d",
+    "statusBar.noFolderBorder": "#0d3a58",
     "statusBar.noFolderForeground": "#aaa",
     "statusBarItem.activeBackground": "#0088ff",
     "statusBarItem.hoverBackground": "#0d3a58",
@@ -277,8 +279,7 @@
     "welcomePage.buttonHoverBackground": "#0d3a58",
     "widget.shadow": "#00000026"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "Comment",
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
@@ -494,10 +495,8 @@
       }
     },
     {
-      "name":
-        "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
-      "scope":
-        "punctuation.definition.string.begin, punctuation.definition.string.end",
+      "name": "[HTML] - Quotes. these are a slightly different colour because expand selection will then not include quotes",
+      "scope": "punctuation.definition.string.begin, punctuation.definition.string.end",
       "settings": {
         "foreground": "#92fc79"
       }


### PR DESCRIPTION
- Change active debugging foreground text color to theme yellow.
- Change active debugging top border color to theme yellow.
- Keep the default top border color when no folder is selected (missing rule).
- Format values that are arrays into one line.

This closes #96 