### PR TITLE
italic for CSS Entity. CSS demo adds

### DIFF
--- a/demo/css.css
+++ b/demo/css.css
@@ -1,7 +1,51 @@
-.someClass {
-  font-family: sans;
+body {
+  position: relative
 }
 
-#someID {
-  background: yellow;
+.table code {
+  font-size: 13px;
+  font-weight: 400
+}
+
+h2 code, h3 code, h4 code {
+  background-color: inherit
+}
+
+.btn-outline {
+  color: #563d7c;
+  background-color: transparent;
+  border-color: #563d7c
+}
+
+.btn-outline:active, .btn-outline:focus, .btn-outline:hover {
+  color: #fff;
+  background-color: #563d7c;
+  border-color: #563d7c
+}
+
+#skippy {
+  display: block;
+  padding: 1em;
+  color: #fff;
+  background-color: #6f5499;
+  outline: 0
+}
+
+#skippy .skiplink-text {
+  padding: .5em;
+  outline: 1px dotted
+}
+
+#content:focus {
+  outline: 0
+}
+
+@media (min-width:768px) {
+  .bs-docs-footer {
+      text-align: left
+  }
+
+  .bs-docs-footer p {
+      margin-bottom: 0
+  }
 }

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -412,6 +412,7 @@
         "source.stylus entity"
       ],
       "settings": {
+        "fontStyle": "italic",
         "foreground": "#3ad900"
       }
     },


### PR DESCRIPTION
Added some Italicizing for CSS Entity.  This will make class identifiers italic for Operator Mono allowing for fast and easy distinguishing of classes and IDs.  