### PR TITLE
Fixes yellow dirty tab circle in VSCode 1.25

### DIFF
--- a/cobalt2-custom-hacks.css
+++ b/cobalt2-custom-hacks.css
@@ -7,8 +7,7 @@
   .monaco-workbench
   > .part.editor
   > .content
-  > .one-editor-silo
-  > .container
+  .editor-group-container
   > .title
   .tabs-container
   > .tab.dirty
@@ -17,11 +16,11 @@
     50% no-repeat;
 }
 
-.monaco-workbench > .editor > .content > .one-editor-silo {
+.monaco-workbench > .part.editor > .content .editor-group-container {
   border-top: 1px solid #15232d !important;
 }
 
-.one-editor-silo + .one-editor-silo {
+.editor-group-container + .editor-group-container {
   border-left: 1px solid #15232d !important;
 }
 


### PR DESCRIPTION
VSCode modified the elements structure and ".one-editor-silo" class name to ".editor-group-container".

Not sure about line 23 ".editor-group-container + .editor-group-container {...}".

About my VSCode:
Version: 1.25.0
Commit: 0f080e5267e829de46638128001aeb7ca2d6d50e
Date: 2018-07-05T13:11:58.697Z
Electron: 1.7.12
Chrome: 58.0.3029.110
Node.js: 7.9.0
V8: 5.8.283.38
Architecture: x64