### PR TITLE
Added JSX Text support

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -331,6 +331,17 @@
       }
     },
     {
+        "name": "Meta JSX",
+        "scope": [
+            "meta.jsx.children",
+            "meta.jsx.children.js",
+            "meta.jsx.children.tsx"
+        ],
+        "settings": {
+            "foreground": "#fff"
+        }
+    },
+    {
       "name": "Meta Brace",
       "scope": "meta.brace",
       "settings": {


### PR DESCRIPTION
Request to add support for JSX text nodes which currently display with the same color as Tag Names, #9effff. This can be seen when viewing the below file with Cobalt2 enabled:

```
class Example extends React.Component {
	render() {
		return (
			<div>
				<span>Example of Syntax Highlighting</span>
            </div>
        );
    }
}
```

The "Example of Syntax Highlighting" text should appear in blue rather than white as it does with standard HTML.