### PR TITLE
Fixes #124 and #127

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -50,7 +50,7 @@
     // When you hover over something and a popup shows, this highlights that thing
     "editor.hoverHighlightBackground": "#ffc60033",
     // when you have something selected, but have lost focus on the editor
-    "editor.inactiveSelectionBackground": "#193549",
+    "editor.inactiveSelectionBackground": "#003b8b",
     // current line styles
     "editor.lineHighlightBackground": "#1F4662",
     "editor.lineHighlightBorder": "#234E6D",
@@ -144,6 +144,8 @@
     "list.hoverForeground": "#aaa",
     "list.inactiveSelectionBackground": "#0d3a58",
     "list.inactiveSelectionForeground": "#aaa",
+    // menu
+    "menu.background": "#122738",
     // merge
     "merge.border": "#ffffff00",
     "merge.commonContentBackground": "#c97d0c",


### PR DESCRIPTION
* Changes right click menu color to something different than the editor background color
* Changes inactive selection color to something different than the editor background color

Here is a screenshot for comparison
![screenshot from 2018-12-05 19-19-12](https://user-images.githubusercontent.com/223984/49527408-e094eb80-f8c2-11e8-91d5-87ec33165c8f.png)

This closes #124 and closes #127
