### PR TITLE
Add csharp specific highlighting

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -803,6 +803,27 @@
       "settings": {
         "fontStyle": "italic"
       }
+    },
+    {
+      "name": "[CSHARP] - Modifiers and keyword types",
+      "scope": "storage.modifier.cs, keyword.type.cs",
+      "settings": {
+        "foreground": "#fb94ff"
+      }
+    },
+    {
+      "name": "[CSHARP] - Storage types",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#80ffbb"
+      }
+    },
+    {
+      "name": "[CSHARP] - Namespaces, parameters, field variables, properties",
+      "scope": "entity.name.type.namespace.cs, entity.name.variable.parameter.cs, entity.name.variable.field.cs, entity.name.variable.property.cs",
+      "settings": {
+        "foreground": "#e1efff"
+      }
     }
   ]
 }


### PR DESCRIPTION
The highlighting for csharp was not very easy to read with a lot of things being the same color. I've tweaked it a bit to have things be different where they should be.

Before: 
![cobalt2before](https://user-images.githubusercontent.com/13209244/51839343-f927ed80-22d6-11e9-8f97-f0960f963b56.png)

After:
![cobalt2after](https://user-images.githubusercontent.com/13209244/51838959-cc270b00-22d5-11e9-988a-d16a3f3478dc.png)
