### PR TITLE
Fix gitignore files showing as bright pink

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -262,7 +262,7 @@
     "gitDecoration.modifiedResourceForeground": "#ffc600",
     "gitDecoration.deletedResourceForeground": "#ff628c",
     "gitDecoration.untrackedResourceForeground": "#3ad900",
-    "gitDecoration.ignoredResourceForeground": "#747476",
+    "gitDecoration.ignoredResourceForeground": "#808080",
     "gitDecoration.conflictingResourceForeground": "#FF7200",
     // textBlockQuote
     "textBlockQuote.background": "#193549",


### PR DESCRIPTION
fixes #93 

**Before:**
![Screenshot 2019-07-02 at 01 18 18](https://user-images.githubusercontent.com/3104587/60458489-eee49380-9c68-11e9-8ae5-ff03abb1ea36.png)

**After:**
![Screenshot 2019-07-02 at 01 24 36](https://user-images.githubusercontent.com/3104587/60458492-f2781a80-9c68-11e9-85dc-4a4e3746cfd5.png)
