### PR TITLE
Invert tab colours to follow common design convention

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -84,7 +84,7 @@
     "editorGroup.dropBackground": "#12273899",
     // editorGroupHeader
     "editorGroupHeader.noTabsBackground": "#193549",
-    "editorGroupHeader.tabsBackground": "#193549",
+    "editorGroupHeader.tabsBackground": "#122738",
     "editorGroupHeader.tabsBorder": "#15232d",
     // editorHoverWidget
     "editorHoverWidget.background": "#15232d",
@@ -229,11 +229,11 @@
     "statusBarItem.prominentBackground": "#15232d",
     "statusBarItem.prominentHoverBackground": "#0d3a58",
     // tab
-    "tab.activeBackground": "#122738",
+    "tab.activeBackground": "#193549",
     "tab.activeForeground": "#fff",
     "tab.border": "#15232D",
     "tab.activeBorder": "#ffc600",
-    "tab.inactiveBackground": "#193549",
+    "tab.inactiveBackground": "#122738",
     "tab.inactiveForeground": "#aaa",
     "tab.unfocusedActiveForeground": "#aaa",
     "tab.unfocusedInactiveForeground": "#aaa",

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -3,6 +3,9 @@
   "name": "Cobalt",
   "type": "dark",
   "colors": {
+    // menu
+    "menu.selectionForeground": "#fff",
+    "menubar.selectionBackground": "#0d3a58",
     // activityBar
     "activityBar.background": "#122738",
     "activityBar.border": "#0d3a58",


### PR DESCRIPTION
Swapping the active and inactive tab colours might be a good idea. Just to follow the common design convention of having the tab colour match the background of the currently selected tab.

Was finding there was some confusion when only 2 tabs were open. With more tabs open this change doesn't matter as much. Could be worth thinking about, even if this change doesn't make it upstream.