### PR TITLE
Update cobalt2-custom-hacks.css

### DIFF
--- a/cobalt2-custom-hacks.css
+++ b/cobalt2-custom-hacks.css
@@ -3,15 +3,7 @@
 }
 
 /* This makes the dirty tab circle yellow */
-.vs-dark
-  .monaco-workbench
-  > .part.editor
-  > .content
-  .editor-group-container
-  > .title
-  .tabs-container
-  > .tab.dirty
-  .close-editor-action {
+.hc-black .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container>.tab.dirty .close-editor-action, .vs-dark .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container>.tab.dirty .close-editor-action {
   background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' height='16' width='16'%3E%3Ccircle fill='%23ffc600' cx='8' cy='8' r='4'/%3E%3C/svg%3E")
     50% no-repeat;
 }


### PR DESCRIPTION
The "dirty tab circle 😆" became grey on my vscode. I tried many things, but the only one that solved the problem was this change. 
Hope I am being helpful 😄!