### PR TITLE
Update CSS for dirty tab circle / cross

### DIFF
--- a/cobalt2-custom-hacks.css
+++ b/cobalt2-custom-hacks.css
@@ -2,19 +2,11 @@
   font-family: "Operator Mono", "Inconsolata", monospace;
 }
 
-/* This makes the dirty tab circle yellow */
-.vs-dark
-  .monaco-workbench
-  > .part.editor
-  > .content
-  .editor-group-container
-  > .title
-  .tabs-container
-  > .tab.dirty
-  .close-editor-action {
-  background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' height='16' width='16'%3E%3Ccircle fill='%23ffc600' cx='8' cy='8' r='4'/%3E%3C/svg%3E")
-    50% no-repeat;
-}
+/* This makes the dirty tab circle & cross yellow */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-close .action-label:not(:hover):before,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty > .tab-close .action-label:not(:hover):before,
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-close .action-label:hover:before,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty > .tab-close .action-label:hover:before { color: #ffc600; }
 
 .monaco-workbench > .part.editor > .content .editor-group-container {
   border-top: 1px solid #15232d !important;


### PR DESCRIPTION
This PR adjusts the selector and CSS properties for the dirty tab circle and cross (hover while in dirty state).
![dirty-tab](https://user-images.githubusercontent.com/1640079/69753153-25a8d200-1153-11ea-88bb-88158354476e.gif)
