### PR TITLE
Improved punctuation

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -28,7 +28,6 @@
     // activityBar
     "activityBar.background": "#122738",
     "activityBar.border": "#0d3a58",
-    "activityBar.dropBackground": "#0d3a58",
     "activityBar.foreground": "#fff",
     "activityBarBadge.background": "#ffc600",
     "activityBarBadge.foreground": "#000",
@@ -101,7 +100,7 @@
     "editorGutter.deletedBackground": "#A22929",
     "editorGutter.modifiedBackground": "#26506D",
     // editorGroup
-    "editorGroup.background": "#A22929",
+    "editorGroup.emptyBackground": "#A22929",
     "editorGroup.border": "#122738",
     "editorGroup.dropBackground": "#12273899",
     // editorGroupHeader
@@ -360,21 +359,21 @@
       "name": "Meta Brace",
       "scope": "meta.brace",
       "settings": {
-        "foreground": "#e1efff"
+        "foreground": "#a0a9b9"
       }
     },
     {
       "name": "Punctuation",
       "scope": "punctuation",
       "settings": {
-        "foreground": "#e1efff"
+        "foreground": "#a0a9b9"
       }
     },
-    {
+    { 
       "name": "Punctuation Parameters",
       "scope": "punctuation.definition.parameters",
       "settings": {
-        "foreground": "#ffee80"
+        "foreground": "#a0a9b9"
       }
     },
     {
@@ -382,6 +381,16 @@
       "scope": "punctuation.definition.template-expression",
       "settings": {
         "foreground": "#ffee80"
+      }
+    },
+    {
+      "name": "Punctuation section embedded (i.e. JS blocks in JSX)",
+      "scope": [
+        "punctuation.section.embedded.begin",
+        "punctuation.section.embedded.end"
+      ],
+      "settings": {
+        "foreground": "#ff628c"
       }
     },
     {
@@ -781,7 +790,7 @@
       "name": "[TYPESCRIPT] - Punctuation Parameters",
       "scope": "source.ts punctuation.definition.parameters",
       "settings": {
-        "foreground": "#e1efff"
+        "foreground": "#a0a9b9"
       }
     },
     {


### PR DESCRIPTION
I dimmed punctuation because previously it was blending in with other light-colored tokens. 
With this change I feel that visual noise-signal ratio is reduced. 
Also embedded JS blocks inside JSX now have distinctly highlighted brackets making it easier to read.

### Before  -  After
![before-after](https://user-images.githubusercontent.com/42813112/117844131-1c002500-b288-11eb-8efa-83053a0abebc.png)
