### PR TITLE
Add border to checkboxes in settings UI

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -217,6 +217,8 @@
     "scrollbarSlider.hoverBackground": "#406179cc",
     // selection
     "selection.background": "#027dff",
+    // settings
+    "settings.checkboxBorder": "#aaa",
     // sidebar
     "sideBar.background": "#15232d",
     "sideBar.border": "#0d3a58",


### PR DESCRIPTION
It's hard to spot checkboxes in the settings UI.
This PR adds a border to checkboxes.


<img width="1012" alt="Screenshot 2021-06-08 at 23 07 29" src="https://user-images.githubusercontent.com/3627515/121264577-41944480-c8af-11eb-8bcf-03a775a4d8c1.png">
👆 BEFORE



👇 AFTER
<img width="1012" alt="Screenshot 2021-06-08 at 23 07 08" src="https://user-images.githubusercontent.com/3627515/121264652-68527b00-c8af-11eb-9ba9-6829a48d3e36.png">

