### PR TITLE
Add `sash.hoverBorder`

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -210,6 +210,8 @@
     "pickerGroup.foreground": "#aaa",
     // progressBar
     "progressBar.background": "#ffc600",
+    // sash
+    "sash.hoverBorder": "#ffc600",
     // scrollbar
     "scrollbar.shadow": "#00000000",
     "scrollbarSlider.activeBackground": "#355166cc",


### PR DESCRIPTION
Borders are easier to see when hover.

**Before**
![image](https://user-images.githubusercontent.com/65824941/130915756-f96b3a86-da96-418d-9f81-59040b6a4334.png)

**After**
![image](https://user-images.githubusercontent.com/65824941/130916139-0d396239-5133-4533-8dfe-e3a467855f8a.png)
