### PR TITLE
adds colors to support gitlens hover

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -293,34 +293,6 @@
   },
   "tokenColors": [
     {
-      "name": "Markup Inserted",
-      "scope": ["markup.inserted", "meta.diff.header.to-file"],
-      "settings": {
-        "foreground": "#a5ff90"
-      }
-    },
-    {
-      "name": "Markup Inserted Punctuation",
-      "scope": ["punctuation.definition.inserted"],
-      "settings": {
-        "foreground": "#a5ff9077"
-      }
-    },
-    {
-      "name": "Markup Deleted",
-      "scope": ["markup.deleted", "meta.diff.header.from-file"],
-      "settings": {
-        "foreground": "#ff628c"
-      }
-    },
-    {
-      "name": "Markup Deleted Punctuation",
-      "scope": ["punctuation.definition.deleted"],
-      "settings": {
-        "foreground": "#ff628c77"
-      }
-    },
-    {
       "name": "Comment",
       "scope": [
         "comment",
@@ -364,6 +336,34 @@
       "scope": "keyword, storage.type.class, keyword.control.default.ts",
       "settings": {
         "foreground": "#ff9d00"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": ["markup.inserted", "meta.diff.header.to-file"],
+      "settings": {
+        "foreground": "#a5ff90"
+      }
+    },
+    {
+      "name": "Markup Inserted Punctuation",
+      "scope": ["punctuation.definition.inserted"],
+      "settings": {
+        "foreground": "#a5ff90cc"
+      }
+    },
+    {
+      "name": "Markup Deleted",
+      "scope": ["markup.deleted", "meta.diff.header.from-file"],
+      "settings": {
+        "foreground": "#ff628c"
+      }
+    },
+    {
+      "name": "Markup Deleted Punctuation",
+      "scope": ["punctuation.definition.deleted"],
+      "settings": {
+        "foreground": "#ff628ccc"
       }
     },
     {

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -293,6 +293,34 @@
   },
   "tokenColors": [
     {
+      "name": "Markup Inserted",
+      "scope": ["markup.inserted", "meta.diff.header.to-file"],
+      "settings": {
+        "foreground": "#a5ff90"
+      }
+    },
+    {
+      "name": "Markup Inserted Punctuation",
+      "scope": ["punctuation.definition.inserted"],
+      "settings": {
+        "foreground": "#a5ff9077"
+      }
+    },
+    {
+      "name": "Markup Deleted",
+      "scope": ["markup.deleted", "meta.diff.header.from-file"],
+      "settings": {
+        "foreground": "#ff628c"
+      }
+    },
+    {
+      "name": "Markup Deleted Punctuation",
+      "scope": ["punctuation.definition.deleted"],
+      "settings": {
+        "foreground": "#ff628c77"
+      }
+    },
+    {
       "name": "Comment",
       "scope": [
         "comment",


### PR DESCRIPTION
Hey, @wesbos — Happy hacktoberfest to you good sir! 

This PR addresses issue #185 reported by @kingcard1131.

Here is a before and after:
![before and after screenshot](https://user-images.githubusercontent.com/10472610/135623539-63ff744a-6bfe-4408-9a25-dd761de54151.png)

I discovered these new token scopes by digging thru https://github.com/primer/github-vscode-theme/blob/a9acf82f22bf810baf445b6efe5689aa89b4949c/src/theme.js#L487-L508... very informative. Also they have a really sweet theming setup over there 😻 if you've not seen it, check it out.

Thanks for considering!