### PR TITLE
Made whitespace characters brighter.

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -133,7 +133,7 @@
     // editorWarning
     "editorWarning.border": "#ffffff00",
     "editorWarning.foreground": "#ffc600",
-    "editorWhitespace.foreground": "#ffffff1a",
+    "editorWhitespace.foreground": "#ffffff52",
     "editorWidget.background": "#15232d",
     "editorWidget.border": "#0d3a58",
     "errorForeground": "#A22929",


### PR DESCRIPTION
The whitespace characters was really hard to see. Made then brighter.

![Cobalt2Theme](https://user-images.githubusercontent.com/6574240/146523920-697ff054-6938-4b4c-afc6-a312220be13c.png)
