### PR TITLE
[FIX] Terminal cursor background colour

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -266,7 +266,7 @@
     "terminal.ansiBrightWhite": "#ffffff",
     "terminal.background": "#122738",
     "terminal.foreground": "#ffffff",
-    "terminalCursor.background": "#ffc600",
+    "terminalCursor.background": "#122738",
     "terminalCursor.foreground": "#ffc600",
     // Git status colors in File Explorer
     "gitDecoration.modifiedResourceForeground": "#ffc600",


### PR DESCRIPTION
+ This commit addresses issue #200 

Fixed an issue where text under the terminal cursor would be invisible.

Previous version: 
![image](https://user-images.githubusercontent.com/38215510/188014336-a62e9d60-98d6-4020-a4e7-191512aef3ee.png)

This version: 
![image](https://user-images.githubusercontent.com/38215510/188014373-b6bd9720-5c08-4b4c-8da6-70f299d0f57b.png)

