### PR TITLE
changed scroll-bar color to be more visible

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -213,8 +213,8 @@
     // scrollbar
     "scrollbar.shadow": "#00000000",
     "scrollbarSlider.activeBackground": "#355166cc",
-    "scrollbarSlider.background": "#1F466280",
-    "scrollbarSlider.hoverBackground": "#406179cc",
+    "scrollbarSlider.background": "#406179cc",
+    "scrollbarSlider.hoverBackground": "#437da3cc",
     // selection
     "selection.background": "#027dff",
     // sidebar


### PR DESCRIPTION
## I worked on the issue #197 
- The issue required the need to change the color of the scroll-bar when it is not being hovered as it was difficult to find when working on large files.
- I have completed this.
-I changed the scroll-bar color to the color that was given to the `highlighted scrollbar` then I gave a new color to the `highlighted scrollbar`.
- This way when working on documents, it is easy to see the scrollbar. 

### Color of Regular Scroll-bar Before
![regular_scrollbar_before](https://user-images.githubusercontent.com/67243684/193881084-3fbab811-595e-46bb-bb0a-994cd26ada50.png)

### Color of Regular Scroll-bar Now
![regular_scrollbar_now](https://user-images.githubusercontent.com/67243684/193881152-aa06f545-db2b-46ac-bd78-bbc17e547477.png)

### Color of Scroll-bar on Hover Before
![highlighted_scrollbar_before](https://user-images.githubusercontent.com/67243684/193881198-22275803-d6ca-4f5e-83a8-c15d0a5ae03d.png)

### Color of Scroll-bar on Hover Now
![highlighted_scrollbar_now](https://user-images.githubusercontent.com/67243684/193881239-b45cbf4d-0a5d-4288-b90c-a09e52dd1381.png)


