### PR TITLE
add support for editorInlayHint

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -19,7 +19,7 @@
       "italic": true
     },
     // This colours both object definiton properties, as well as references. If the property does not exist, it will be white\.
-    "property": "#9effff",
+    "property": "#9effff"
   },
   "colors": {
     // menu
@@ -112,6 +112,8 @@
     "editorHoverWidget.background": "#15232d",
     "editorHoverWidget.border": "#0d3a58",
     "editorIndentGuide.background": "#3B5364",
+    "editorInlayHint.foreground": "#ff68b8",
+    "editorInlayHint.background": "#0000001a",
     "editorLineNumber.foreground": "#aaa",
     "editorLink.activeForeground": "#aaa",
     // editorMarkerNavigation
@@ -294,10 +296,7 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "#0088ff"
@@ -400,20 +399,14 @@
     },
     {
       "name": "String",
-      "scope": [
-        "string",
-        "punctuation.definition.string"
-      ],
+      "scope": ["string", "punctuation.definition.string"],
       "settings": {
         "foreground": "#a5ff90"
       }
     },
     {
       "name": "String Template",
-      "scope": [
-        "string.template",
-        "punctuation.definition.string.template"
-      ],
+      "scope": ["string.template", "punctuation.definition.string.template"],
       "settings": {
         "foreground": "#3ad900"
       }
@@ -448,10 +441,7 @@
     },
     {
       "name": "[CSS] - Entity",
-      "scope": [
-        "source.css entity",
-        "source.stylus entity"
-      ],
+      "scope": ["source.css entity", "source.stylus entity"],
       "settings": {
         "foreground": "#3ad900"
       }
@@ -472,10 +462,7 @@
     },
     {
       "name": "[CSS] - Support",
-      "scope": [
-        "source.css support",
-        "source.stylus support"
-      ],
+      "scope": ["source.css support", "source.stylus support"],
       "settings": {
         "foreground": "#a5ff90"
       }
@@ -506,10 +493,7 @@
     },
     {
       "name": "[CSS] - Variable",
-      "scope": [
-        "source.css variable",
-        "source.stylus variable"
-      ],
+      "scope": ["source.css variable", "source.stylus variable"],
       "settings": {
         "foreground": "#9effff"
       }
@@ -724,20 +708,14 @@
     },
     {
       "name": "[MARKDOWN] - Inline Code",
-      "scope": [
-        "fenced_code.block.language",
-        "markup.inline.raw.markdown"
-      ],
+      "scope": ["fenced_code.block.language", "markup.inline.raw.markdown"],
       "settings": {
         "foreground": "#9effff"
       }
     },
     {
       "name": "[MARKDOWN] - Code Block",
-      "scope": [
-        "fenced_code.block.language",
-        "markup.inline.raw.markdown"
-      ],
+      "scope": ["fenced_code.block.language", "markup.inline.raw.markdown"],
       "settings": {
         "foreground": "#9effff"
       }
@@ -848,9 +826,7 @@
     },
     {
       "name": "Export Default",
-      "scope": [
-        "keyword.control.export"
-      ],
+      "scope": ["keyword.control.export"],
       "settings": {
         "foreground": "#ff9d00",
         "fontStyle": "italic"
@@ -858,13 +834,11 @@
     },
     {
       "name": "[TYPESCRIPT] Returned Type",
-      "scope": [
-        "meta.return.type.ts"
-      ],
+      "scope": ["meta.return.type.ts"],
       "settings": {
         "foreground": "#ff0088",
         "fontStyle": "italic"
       }
-    },
+    }
   ]
 }


### PR DESCRIPTION
This PR implements support for `editorInlayHint` via https://github.com/wesbos/cobalt2-vscode/issues/198.

![inlayhints-before-after](https://user-images.githubusercontent.com/10472610/197040571-6a39b724-2233-41a1-925e-836b6df64185.png)
