### PR TITLE
Removed distracting borders on the changed parts in the diff editor

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -50,9 +50,9 @@
     "descriptionForeground": "#aaa",
     // diff
     "diffEditor.insertedTextBackground": "#3ad90033",
-    "diffEditor.insertedTextBorder": "#3ad90055",
+    "diffEditor.insertedTextBorder": "#00000000",
     "diffEditor.removedTextBackground": "#ee3a4333",
-    "diffEditor.removedTextBorder": "#ee3a4355",
+    "diffEditor.removedTextBorder": "#00000000",
     // dropdown
     "dropdown.background": "#193549",
     "dropdown.border": "#15232d",


### PR DESCRIPTION
In the diff editor, the borders around the lines -and parts of lines- added or removed can be a bit overwhelming.

I propose to remove them, and think the result is much cleaner, which improves the diff editor experience overall.

## Comparison 1
### Before
![Capture d’écran 2023-02-05 à 17 15 13](https://user-images.githubusercontent.com/60618354/216831240-2b5a9668-f04d-49f9-9dc8-80326e97d479.png)
### After
(note that the lines with borders seen here are where the cursor is positioned)
![Capture d’écran 2023-02-05 à 17 17 47](https://user-images.githubusercontent.com/60618354/216831308-f7f8b8fa-5f0b-4f29-8efc-551128dd668e.png)

## Comparison 2
### Before
![Capture d’écran 2023-02-05 à 17 16 20](https://user-images.githubusercontent.com/60618354/216831248-ca6d7e34-6243-450f-ad8d-22b8df41c975.png)
### After
(note that the lines with borders seen here are where the cursor is positioned)
![Capture d’écran 2023-02-05 à 17 18 50](https://user-images.githubusercontent.com/60618354/216831322-2e40d653-0207-4c7e-b260-862f6366f656.png)
