### PR TITLE
make statusBar.remote colors look normal

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -243,6 +243,8 @@
     "statusBarItem.hoverBackground": "#0d3a58",
     "statusBarItem.prominentBackground": "#15232d",
     "statusBarItem.prominentHoverBackground": "#0d3a58",
+    "statusBarItem.remoteBackground": "#15232d",
+    "statusBarItem.remoteForeground": "#aaa",
     // tab
     "tab.activeBackground": "#193549",
     "tab.activeForeground": "#fff",


### PR DESCRIPTION
This commit fixes issue #220 and makes the ```statusBarItem.remoteBackground``` and ```statusBarItem.remoteForeground``` colors match the rest of the status bar so that it doesn't weirdly stand out. 

Only third time committing to a repository that isn't my own, and first time doing it without help, let me know if I messed something up or if this was ok.

Stephen

P.S. Love Syntax, thanks for all you guys do.