### PR TITLE
How to remove italics? #207

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -616,8 +616,7 @@
     {
       "name": "[PYTHON] - Self Argument",
       "scope": [
-        "variable.parameter.function.language.special.self.python",
-        "meta.function-call.generic.python"
+        "meta.function-call.generic.python",
       ],
       "settings": {
         "foreground": "#9effff"
@@ -625,7 +624,10 @@
     },
     {
       "name": "[PYTHON] - Function Call Argument",
-      "scope": ["meta.function-call.arguments.python"],
+      "scope": [
+        "meta.function-call.arguments.python",
+        "variable.parameter.function.language.special.self.python"
+      ],
       "settings": {
         "foreground": "#fb94ff"
       }

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -15,8 +15,7 @@
     },
     "type": {
       // "foreground": "#ff0088",
-      "foreground": "#FF68B8",
-      "italic": true
+      "foreground": "#FF68B8"
     },
     // This colours both object definiton properties, as well as references. If the property does not exist, it will be white\.
     "property": "#9effff"
@@ -616,7 +615,10 @@
     },
     {
       "name": "[PYTHON] - Self Argument",
-      "scope": ["variable.parameter.function.language.special.self.python","meta.function-call.generic.python"],
+      "scope": [
+        "variable.parameter.function.language.special.self.python",
+        "meta.function-call.generic.python"
+      ],
       "settings": {
         "foreground": "#9effff"
       }


### PR DESCRIPTION
Is it possible to remove italics completely?
![image](https://user-images.githubusercontent.com/125372245/231357258-deb2bc7e-cef7-4a8d-9581-51a009636adf.png)
For example, remove italics from type?

output look like after change
![image](https://user-images.githubusercontent.com/125372245/231357399-f6725e21-c127-4c03-be82-dba26f4790c6.png)
