### PR TITLE
Semantic Highlight Improvement for Python #233

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -616,8 +616,7 @@
     {
       "name": "[PYTHON] - Self Argument",
       "scope": [
-        "variable.parameter.function.language.special.self.python",
-        "meta.function-call.generic.python"
+        "meta.function-call.generic.python",
       ],
       "settings": {
         "foreground": "#9effff"
@@ -625,7 +624,10 @@
     },
     {
       "name": "[PYTHON] - Function Call Argument",
-      "scope": ["meta.function-call.arguments.python"],
+      "scope": [
+        "meta.function-call.arguments.python",
+        "variable.parameter.function.language.special.self.python"
+      ],
       "settings": {
         "foreground": "#fb94ff"
       }

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -15,8 +15,7 @@
     },
     "type": {
       // "foreground": "#ff0088",
-      "foreground": "#FF68B8",
-      "italic": true
+      "foreground": "#FF68B8"
     },
     // This colours both object definiton properties, as well as references. If the property does not exist, it will be white\.
     "property": "#9effff"
@@ -616,7 +615,10 @@
     },
     {
       "name": "[PYTHON] - Self Argument",
-      "scope": ["variable.parameter.function.language.special.self.python","meta.function-call.generic.python"],
+      "scope": [
+        "variable.parameter.function.language.special.self.python",
+        "meta.function-call.generic.python"
+      ],
       "settings": {
         "foreground": "#9effff"
       }


### PR DESCRIPTION
Apologies for the delayed response, as I haven't been actively checking GitHub lately. 

![image](https://github.com/wesbos/cobalt2-vscode/assets/125372245/48e20426-93ee-405f-96a9-cb5b42370d92)

I solve this `self` parameter lose its highlight when semantic tokens are enabled issue and create new pull request please check new pull request and let me know.

![image](https://github.com/wesbos/cobalt2-vscode/assets/125372245/472df9a7-f367-4a18-b781-e6e5edff2468)
