### PR TITLE
fix: Python highlighting issues

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -618,14 +618,7 @@
     },
     {
       "name": "[PYTHON] - Self Argument",
-      "scope": ["variable.parameter.function.language.special.self.python","meta.function-call.generic.python"],
-      "settings": {
-        "foreground": "#9effff"
-      }
-    },
-    {
-      "name": "[PYTHON] - Function Call Argument",
-      "scope": ["meta.function-call.arguments.python"],
+      "scope": "variable.parameter.function.language.special.self.python",
       "settings": {
         "foreground": "#fb94ff"
       }

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -8,6 +8,22 @@
       "foreground": "#ffc600"
     },
     "variable": "#fff",
+    // In JS/TS, variable declared with `const` is recognized as readonly
+    // Therefore, it's necessary to specify the language
+    "variable.readonly:python": {
+      "foreground": "#FF628C"
+    },
+    "*.decorator:python": {
+      "fontStyle": "italic bold"
+    },
+    "selfParameter:python": {
+        "foreground": "#fb94ff",
+        "fontStyle": "italic"
+    },
+    "clsParameter:python": {
+        "foreground": "#fb94ff",
+        "fontStyle": "italic"
+    },
     "interface": {
       // "foreground": "#ff0088",
       "foreground": "#FF68B8",
@@ -620,7 +636,22 @@
       "name": "[PYTHON] - Self Argument",
       "scope": "variable.parameter.function.language.special.self.python",
       "settings": {
+        "fontStyle": "italic",
         "foreground": "#fb94ff"
+      }
+    },
+    {
+      "name": "[PYTHON] - Method Declaration",
+      "scope": "entity.name.function.decorator.python",
+      "settings": {
+        "fontStyle": "italic bold"
+      }
+    },
+    {
+      "name": "[PYTHON] - Declaration Leading Punctuation @",
+      "scope": "punctuation.definition.decorator.python",
+      "settings": {
+        "foreground": "#FF68B8",
       }
     },
     {


### PR DESCRIPTION
This PR reverts disapproved #223, improving Python semantic highlighting features, with #232 finished. #223 happened to remove the highlight of `self` keyword, which is mentioned in #233. 

The [syntax highlighting](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide) and [semantic highlighting](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide) work together to provide the developers with more recognizable tokens. Semantic highlighting is more powerful, and generally more precise. It's highly recommended to turn on semantic highlighting features in VS Code.
<blockquote>
To enable it, install the corresponding language support extension (typically a <a href="https://code.visualstudio.com/api/language-extensions/language-server-extension-guide">language server</a>, for example, <a href="https://code.visualstudio.com/api/language-extensions/language-server-extension-guide">Pylance</a> for Python), and configure in your settings.json:

  ```jsonc
      "editor.semanticHighlighting.enabled": true
  ```
This setting entry is `true` by default, in case someone unexpectedly set it to `false`.
</blockquote>

No semantic:
![no-semantic](https://github.com/wesbos/cobalt2-vscode/assets/93167100/b04b9822-50d0-42e8-9514-e05731c80afa)

With semantic:
![no-semantic](https://github.com/wesbos/cobalt2-vscode/assets/93167100/dc6765f7-faa2-43cd-a411-aae207296c91)

In addition, since semantic highlighting overrides common syntax highlighting, it also offers the abilities to customize the token color with much flexibility. See [this example](https://github.com/wesbos/cobalt2-vscode/issues/207#issuecomment-1685177054).

Therefore, this PR expands the semantic highlighting feature on Python language. I've made the changes for one more months, and I didn't detect any side effects (like accidentally changing other language's highlighting color).

## Detailed changes:
1. Fix the `self` keyword problem. This is done by reverting #223 and add rules into `"semanticTokenColors"`.
![image](https://github.com/wesbos/cobalt2-vscode/assets/93167100/ec9c0e9d-cf9c-4d5a-9a3b-57271a50b928)

2. Add additional highlighting to Python function decorators.
![decorator](https://github.com/wesbos/cobalt2-vscode/assets/93167100/65999a51-9a21-46f8-8d40-5ab7409821ff)

PS: 

- About #218: I suggest turn on the semantic highlighting feature, rather than focus on the native syntax tokens. It's hard to strike a balance, and can easily produce side effects.
- Is it necessary to revert #223? Yes. It acts strangely, no matter whether the semantic highlighting is enabled.
With semantic:
![1](https://github.com/wesbos/cobalt2-vscode/assets/93167100/cd3cafbc-90be-458c-aa44-79ae9e33d11c)
Without semantic:
![2](https://github.com/wesbos/cobalt2-vscode/assets/93167100/16efe48f-659a-4122-90b9-fb6379e0f047)

Thanks for your checking! @wesbos @palashmon 