### PR TITLE
fix: debug console error color (#234)

### DIFF
--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -43,6 +43,7 @@
     // "contrastActiveBorder": null,
     "contrastBorder": "#ffffff00",
     // debug
+    "debugConsole.errorForeground": "#ff5630",
     "debugExceptionWidget.background": "#193549",
     "debugExceptionWidget.border": "#aaa",
     "debugToolBar.background": "#193549",


### PR DESCRIPTION
Use a lighter red. (in https://github.com/wesbos/cobalt2-vscode/issues/234#issuecomment-1717775146)

![Screenshot 2023-09-14 at 00 30 04](https://github.com/wesbos/cobalt2-vscode/assets/93167100/5d838b55-016f-46f1-ad48-8a792a1cfb12)

Problem:

I find `console.error` and `console.warn` share the same foreground color. Is it the expected behavior? I guess that VS Code define the same API for the two types of output in REPL.

![image](https://github.com/wesbos/cobalt2-vscode/assets/93167100/9ea752e9-389f-401a-9818-25c45be89014)

