### PR TITLE
Enhance Style with Expanded Italics Scope for 'Italicsify for Operator Mono'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,49 @@
 }
 ```
 
+## Extra Cursive Settings
+
+```js
+// Will add extra cursive font to the theme
+  "editor.tokenColorCustomizations": {
+    "textMateRules": [
+      {
+        "scope": [
+          //following will be in italic
+          "comment",
+          "entity.name.type.class", //class names
+          "keyword", //import, export, return…
+          "constant", //String, Number, Boolean…, this, super
+          "storage.modifier", //static keyword
+          "storage.type.class.js", //class keyword
+          "variable.object.property",
+          "variable.other.object.property",
+          "variable.other.property",
+          "variable.other.member",
+          "storage.type",
+        ],
+        "settings": {
+          "fontStyle": "italic"
+        }
+      },
+      {
+        "scope": [
+          //following will be excluded from italics (VSCode has some defaults for italics)
+          "invalid",
+          "keyword.operator",
+          "constant.numeric.css",
+          "keyword.other.unit.px.css",
+          "constant.numeric.decimal.js",
+          "constant.numeric.json"
+        ],
+        "settings": {
+          "fontStyle": ""
+        }
+      }
+    ]
+  },
+```
+
 ## Colours
 
 Blue: #193549

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -854,27 +854,41 @@
     {
       "name": "Italicsify for Operator Mono",
       "scope": [
-        "modifier",
-        "this",
-        "comment",
-        "storage.modifier",
-        "entity.other.attribute-name.js",
-        // "storage.modifier.js",
-        // "storage.modifier.ts",
-        // "storage.modifier.tsx",
-        "entity.other.attribute-name.js",
-        "entity.other.attribute-name.ts",
-        "entity.other.attribute-name.tsx",
-        "entity.other.attribute-name.html",
-        "entity.name.type.class",
-        "keyword",
-        "constant",
-        "storage.type.class.js"
+        "modifier", // General modifiers like public, private in many languages
+        "this", // 'this' keyword in object context
+        "comment", // All comment types
+        "storage.modifier", // Specific modifiers such as static in languages like Java, C#
+        "entity.other.attribute-name.js", // Attribute names in JavaScript objects
+        // "storage.modifier.js", // Uncomment to specifically target static in JavaScript
+        // "storage.modifier.ts", // Uncomment to specifically target static in TypeScript
+        // "storage.modifier.tsx", // Uncomment to specifically target static in TypeScript React
+        "entity.other.attribute-name.ts", // Attribute names in TypeScript objects
+        "entity.other.attribute-name.tsx", // Attribute names in TypeScript React objects
+        "entity.other.attribute-name.html", // Attribute names in HTML tags
+        "entity.name.type.class", // Class names in many languages
+        "keyword", // Keywords in languages (if, for, return, etc.)
+        "constant", // Constants like numbers, string literals, boolean values
+        "storage.type.class.js", // Specific class keyword in JavaScript
+        "storage.type.class.ts" // Specific class keyword in TypeScript
       ],
       "settings": {
         "fontStyle": "italic"
       }
     },
+    {
+      "scope": [
+        "invalid", // Targets invalid tokens or syntax errors
+        "keyword.operator", // Targets operators (+, -, *, /, etc.) in various languages
+        "constant.numeric.css", // Targets numeric values in CSS
+        "keyword.other.unit.px.css", // Targets the 'px' unit specifically in CSS
+        "constant.numeric.decimal.js", // Targets decimal numbers in JavaScript
+        "constant.numeric.json" // Targets numeric values in JSON
+      ],
+      "settings": {
+        "fontStyle": "" // Setting fontStyle to an empty string to ensure no specific style is applied
+      }
+    },
+
     {
       "name": "Export Default",
       "scope": ["keyword.control.export"],

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -854,41 +854,23 @@
     {
       "name": "Italicsify for Operator Mono",
       "scope": [
-        "modifier", // General modifiers like public, private in many languages
-        "this", // 'this' keyword in object context
-        "comment", // All comment types
-        "storage.modifier", // Specific modifiers such as static in languages like Java, C#
-        "entity.other.attribute-name.js", // Attribute names in JavaScript objects
-        // "storage.modifier.js", // Uncomment to specifically target static in JavaScript
-        // "storage.modifier.ts", // Uncomment to specifically target static in TypeScript
-        // "storage.modifier.tsx", // Uncomment to specifically target static in TypeScript React
-        "entity.other.attribute-name.ts", // Attribute names in TypeScript objects
-        "entity.other.attribute-name.tsx", // Attribute names in TypeScript React objects
-        "entity.other.attribute-name.html", // Attribute names in HTML tags
-        "entity.name.type.class", // Class names in many languages
-        "keyword", // Keywords in languages (if, for, return, etc.)
-        "constant", // Constants like numbers, string literals, boolean values
-        "storage.type.class.js", // Specific class keyword in JavaScript
-        "storage.type.class.ts" // Specific class keyword in TypeScript
+        "modifier",
+        "this",
+        "comment",
+        "storage.modifier",
+        "entity.other.attribute-name.js",
+        // "storage.modifier.js",
+        // "storage.modifier.ts",
+        // "storage.modifier.tsx",
+        "entity.other.attribute-name.js",
+        "entity.other.attribute-name.ts",
+        "entity.other.attribute-name.tsx",
+        "entity.other.attribute-name.html"
       ],
       "settings": {
         "fontStyle": "italic"
       }
     },
-    {
-      "scope": [
-        "invalid", // Targets invalid tokens or syntax errors
-        "keyword.operator", // Targets operators (+, -, *, /, etc.) in various languages
-        "constant.numeric.css", // Targets numeric values in CSS
-        "keyword.other.unit.px.css", // Targets the 'px' unit specifically in CSS
-        "constant.numeric.decimal.js", // Targets decimal numbers in JavaScript
-        "constant.numeric.json" // Targets numeric values in JSON
-      ],
-      "settings": {
-        "fontStyle": "" // Setting fontStyle to an empty string to ensure no specific style is applied
-      }
-    },
-
     {
       "name": "Export Default",
       "scope": ["keyword.control.export"],

--- a/theme/cobalt2.json
+++ b/theme/cobalt2.json
@@ -23,6 +23,7 @@
   },
   "colors": {
     // menu
+
     "menu.selectionForeground": "#fff",
     "menubar.selectionBackground": "#0d3a58",
     // activityBar
@@ -621,7 +622,10 @@
     },
     {
       "name": "[PYTHON] - Self Argument",
-      "scope": ["variable.parameter.function.language.special.self.python","meta.function-call.generic.python"],
+      "scope": [
+        "variable.parameter.function.language.special.self.python",
+        "meta.function-call.generic.python"
+      ],
       "settings": {
         "foreground": "#9effff"
       }
@@ -861,7 +865,11 @@
         "entity.other.attribute-name.js",
         "entity.other.attribute-name.ts",
         "entity.other.attribute-name.tsx",
-        "entity.other.attribute-name.html"
+        "entity.other.attribute-name.html",
+        "entity.name.type.class",
+        "keyword",
+        "constant",
+        "storage.type.class.js"
       ],
       "settings": {
         "fontStyle": "italic"


### PR DESCRIPTION
## Proposed changes

I added some settings to extends the scope of "Italicsify for Operator Mono". In my opinion it makes the theme even better.

If the pull request addresses a specific issue or feature request, be sure to reference it here by linking to the relevant issue.

## Screenshots

Include screenshots to demonstrate the changes made by this pull request. This include before-and-after comparisons or specific examples of the modified functionality.

### Before
<!-- Include before screenshot here -->
![CleanShot 2024-04-30 at 11 29 53@2x](https://github.com/wesbos/cobalt2-vscode/assets/53791026/89e0dda5-1e5a-44ac-babf-40cb1fd96064)

### After
<!-- Include after screenshot here -->
![CleanShot 2024-04-30 at 14 56 47@2x](https://github.com/wesbos/cobalt2-vscode/assets/53791026/c563ddb7-604c-42b5-a0fe-a51ee32772f3)

## Checklist

Before submitting this pull request, ensure that you have completed the following tasks:<br>
(_Put an `x` in the boxes that apply._)

- [ x] I have read and understood the [CONTRIBUTING](https://github.com/wesbos/cobalt2-vscode/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ x] I have performed a self-review of my code.
- [ x] I have added relevant screenshots or visual aids to showcase the changes made by this pull request.